### PR TITLE
Actualizar botón de cerrar banner

### DIFF
--- a/ext/lib/site/home-presupuesto/banner-presupuesto/component.js
+++ b/ext/lib/site/home-presupuesto/banner-presupuesto/component.js
@@ -74,7 +74,7 @@ export default class BannerPresupuesto extends Component {
     return (
       this.state.visibility && (
         <div className='container-banner'>
-          <button className='closes' onClick={this.closeBanner}>x</button>
+          <button className='closes' onClick={this.closeBanner}>×</button>
           <h3>
             {texts[key].title}
           </h3>


### PR DESCRIPTION
Usar el signo de multiplicación `&times;`, queda mejor alineado:

**Antes:**
<img width="111" alt="screen shot 2017-11-02 at 11 16 16" src="https://user-images.githubusercontent.com/558901/32330564-43af5eb4-bfbf-11e7-977d-df2cad91ddf7.png">

**Después:**
<img width="119" alt="screen shot 2017-11-02 at 11 16 03" src="https://user-images.githubusercontent.com/558901/32330609-666d1c3e-bfbf-11e7-843f-c98507360f97.png">
