### PR TITLE
Actualizar DOS 2.11.0 y Arreglar privilegios canVoteAndComment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM democracyos/democracyos:2.9.13
+FROM democracyos/democracyos:2.11.0
 
 MAINTAINER Matías Lescano <matias@democraciaenred.org>
 

--- a/ext/lib/site/home-consultas/topic-card/component.js
+++ b/ext/lib/site/home-consultas/topic-card/component.js
@@ -43,9 +43,7 @@ export default ({ forum, topic }) => {
           <Link to={topic.url}>{topic.mediaTitle}</Link>
         </h1>
         {topic.action.method && topic.action.method === 'poll' && (
-          <Poll
-            topic={topic}
-            canVoteAndComment={forum.privileges.canVoteAndComment} />
+          <Poll topic={topic} />
         )}
         <div className='topic-card-footer-container'>
           <div className='topic-card-footer'>

--- a/ext/lib/site/topic-layout/topic-article/component.js
+++ b/ext/lib/site/topic-layout/topic-article/component.js
@@ -121,16 +121,12 @@ class TopicArticle extends Component {
 
                   {
                     topic.action.method && topic.action.method === 'poll' && (
-                      <Poll
-                        topic={topic}
-                        canVoteAndComment={forum.privileges.canVoteAndComment} />
+                      <Poll topic={topic} />
                     )
                   }
                   {
                     topic.action.method && topic.action.method === 'cause' && (
-                      <Cause
-                        topic={topic}
-                        canVoteAndComment={forum.privileges.canVoteAndComment} />
+                      <Cause topic={topic} />
                     )
                   }
                   {


### PR DESCRIPTION
Actualizar a la última versión de https://github.com/DemocracyOS/democracyos

## Cosas a arreglar
- [x] Refactor `forum.privileges.canVoteAndComment` https://github.com/DemocracyOS/democracyos/pull/1524
- [ ] Revisar cambios hechos en DOS `>=2.9.x`
